### PR TITLE
Prevent unstorable types from revealing their values

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Newt.MixProject do
   def project do
     [
       app: :newt,
-      version: "8.1.1",
+      version: "8.2.0",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       aliases: aliases(),

--- a/test/support/example_types.ex
+++ b/test/support/example_types.ex
@@ -27,3 +27,8 @@ defmodule Newt.ExampleIntegerType do
     end
   end
 end
+
+defmodule Newt.ExampleUnstorableType do
+  @moduledoc false
+  use Newt, type: any(), ecto_type: :unstorable
+end


### PR DESCRIPTION
Ok, you can still get at them programatically by decomposing the struct or calling the value property directly, because Elixir, but at least the protocol implementations do the right thing now.